### PR TITLE
Python3 work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.4"
   - "2.7"
   - "2.6"
 install:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Project settings.py
 
     # global support tools/apps
     'supporttools',
+
+    # other apps that are helpful - install separately
     'restclients',
     'userservice',
     'authz_group',
@@ -47,6 +49,8 @@ Project settings.py
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django_mobileesp.middleware.UserAgentDetectionMiddleware',
+
+    # From the userservice app
     'userservice.user.UserServiceMiddleware',
 
 **AUTHENTICATION_BACKENDS**
@@ -66,10 +70,6 @@ Project settings.py
     
     'supporttools.context_processors.supportools_globals',
     'supporttools.context_processors.has_less_compiled',
-
-**TEMPLATE_DIRS**
-
-    'os.path.join(BASE_DIR, 'supporttools', 'templates'),'
 
 Mobile ESP settings...
 
@@ -103,7 +103,7 @@ Other settings...
 
 Project urls.py
 ---------------
-    # support urls
+    # support urls - based on the support tools you install
     url(r'^someadminapp/', include('someadminapp.urls')),
     url(r'^support/', include('supporttools.urls')),
     url(r'^users/', include('userservice.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
--e git+https://github.com/abztrakt/django-mobileesp/#egg=django_mobileesp
--e git+https://github.com/vegitron/authz_group#egg=AuthZGroup
--e git+https://github.com/vegitron/django-userservice#egg=Django-UserService
+# Things need to be added to setup.py, not here.
+-e .

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         'django',
         'django-compressor',
         'django-templatetag-handlebars',
-        'beautifulsoup',
     ],
     license='Apache License, Version 2.0',  # example license
     description='A Django app to ...',


### PR DESCRIPTION
* Dropping everything in requirements.txt.   Didn't line up at all w/ setup.py
* Dropped beautifulsoup from setup.py.  Not python3 compatible (needs beautifulsoup4), and we didn't seem to be using it.
* Rough stab at clarifying requirements in the requirements.txt.  This app should document itself, not everything people might install with it.
* Adding python 3.4 to the test matrix.