### PR TITLE
Updates for travis-ci and Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
 - DJANGO_VERSION=1.10.*
 
 before_script:
+- pip install -U Django==$DJANGO_VERSION
 - pip install -e .
 - pip install pep8
 - pip install coverage
 - pip install python-coveralls
-- pip install -U Django==$DJANGO_VERSION
 - npm install -g jshint
 - cp travis-ci/manage.py manage.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - pip install coverage
 - pip install python-coveralls
 - pip install -U Django==$DJANGO_VERSION
-- npm install jshint
+- npm install -g jshint
 - cp travis-ci/manage.py manage.py
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 - DJANGO_VERSION=1.8.*
 - DJANGO_VERSION=1.9.*
 - DJANGO_VERSION=1.10.*
+- DJANGO_VERSION=1.11.*
 
 before_script:
 - pip install -U Django==$DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ env:
 before_script:
 - pip install -U Django==$DJANGO_VERSION
 - pip install -e .
-- pip install pep8
+- pip install pycodestyle
 - pip install coverage
 - pip install python-coveralls
 - npm install -g jshint
 - cp travis-ci/manage.py manage.py
 
 script:
-- pep8 supporttools/
+- pycodestyle supporttools/
 - jshint supporttools/static/supporttools/js/ --verbose
 - python -m compileall supporttools/
 - coverage run --source=supporttools manage.py test supporttools

--- a/supporttools/templatetags/sidebar_links.py
+++ b/supporttools/templatetags/sidebar_links.py
@@ -1,19 +1,7 @@
 from django import template
+from django.template.loader_tags import IncludeNode
 
 register = template.Library()
-
-
-# From https://djangosnippets.org/snippets/2058/
-# Previous method started failing with Django 1.7
-class IncludeNode(template.Node):
-    def __init__(self, template_name):
-        self.template_name = template_name
-
-    def render(self, context):
-        # Loading the template and rendering it
-        included_template = template.loader.get_template(
-                                self.template_name).render(context)
-        return included_template
 
 
 @register.tag("sidebar_links")
@@ -23,6 +11,6 @@ def do_sidebar_links(parser, token):
     default_template = "supporttools/default_sidelinks.html"
     try:
         template.loader.get_template(custom_template)
-        return IncludeNode(custom_template)
+        return IncludeNode(parser.compile_filter("'%s'" % custom_template))
     except template.TemplateDoesNotExist:
-        return IncludeNode(default_template)
+        return IncludeNode(parser.compile_filter("'%s'" % default_template))

--- a/supporttools/tests/test_sidebar_links.py
+++ b/supporttools/tests/test_sidebar_links.py
@@ -1,0 +1,29 @@
+import os
+
+from django.test import TestCase
+from django.template import Context, Template
+
+
+class TestSidebarLinks(TestCase):
+    def test_default_sidebar(self):
+        with self.settings(TEMPLATES=[{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': '',
+            'APP_DIRS': True,
+        }]):
+            out = Template('{% load sidebar_links %}'
+                           '{% sidebar_links %}').render(Context())
+
+            self.assertInHTML('<h3>General Tools</h3>', out)
+
+    def test_custom_sidebar(self):
+        with self.settings(TEMPLATES=[{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                os.path.join(os.path.dirname(__file__), 'test_templates')],
+            'APP_DIRS': True,
+        }]):
+            out = Template('{% load sidebar_links %}'
+                           '{% sidebar_links %}').render(Context())
+
+            self.assertInHTML('<h3>Custom Tools</h3>', out)

--- a/supporttools/tests/test_templates/supporttools/custom_sidebar_links.html
+++ b/supporttools/tests/test_templates/supporttools/custom_sidebar_links.html
@@ -1,0 +1,9 @@
+<h3>Custom Tools</h3>
+<ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+</ul>
+
+{% if debug_mode %}
+{% include 'supporttools/default_sidelinks.html' %}
+{% endif %}

--- a/travis-ci/urls.py
+++ b/travis-ci/urls.py
@@ -2,7 +2,5 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^oauth/', include('oauth_provider.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^', include('nagios_registration.urls')),
     ]


### PR DESCRIPTION
The build would fail on the newer travis dist (trusty, vs precise), so a couple small changes to fix that. Then I added a test showing how sidebar_links tag was broken on Django 1.11, and the fix for that.