### PR TITLE
enable deprecation warnings, update django test matrix (#71)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,7 @@ name: tests
 env:
   APP_NAME: supporttools
   CONF_PATH: conf
-  COVERAGE_DJANGO_VERSION: 3.2
+  COVERAGE_DJANGO_VERSION: '4.2'
 
 on:
   push:
@@ -42,14 +42,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
         django-version:
-          - '2.2'
           - '3.2'
-          - '4.1'
+          - '4.2'
 
     steps:
       - name: Checkout Repo
@@ -58,22 +57,21 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '12'
+          node-version: '20'
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install python-dev libxml2-dev libxmlsec1-dev
           python -m pip install --upgrade pip
           pip install -e .
-          pip install coverage coveralls==2.2.0
+          pip install coverage coveralls==3.3.1
           npm install -g jshint
 
-      - name: Upgrade Django Version
+      - name: Install Django ${{ matrix.django-version }}
         run: pip install "Django~=${{ matrix.django-version }}.0"
 
       - name: Setup Django
@@ -97,7 +95,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m compileall ${APP_NAME}/
-          coverage run --source=${APP_NAME}/ manage.py test ${APP_NAME}
+          python -Wd -m coverage run --source=${APP_NAME}/ manage.py test ${APP_NAME}
 
       - name: Report Test Coverage
         if: matrix.django-version == env.COVERAGE_DJANGO_VERSION
@@ -111,7 +109,7 @@ jobs:
 
     needs: test
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -120,7 +118,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Publish to PyPi
         uses: uw-it-aca/actions/publish-pypi@main

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/uw-it-aca/django-supporttools/workflows/tests/badge.svg?branch=main)](https://github.com/uw-it-aca/django-supporttools/actions)
 [![Coverage Status](https://coveralls.io/repos/github/uw-it-aca/django-supporttools/badge.svg?branch=main)](https://coveralls.io/github/uw-it-aca/django-supporttools?branch=main)
 [![PyPi Version](https://img.shields.io/pypi/v/django-supporttools.svg)](https://pypi.python.org/pypi/django-supporttools)
-![Python versions](https://img.shields.io/pypi/pyversions/django-supporttools.svg)
+![Python versions](https://img.shields.io/badge/python-3.10-blue.svg)
 
 
 A Django application used for theming and wrapping support tools.

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,18 @@ setup(
     name='Django-SupportTools',
     version=VERSION,
     packages=['supporttools'],
-    author="UW-IT AXDD",
+    author="UW-IT T&LS",
     author_email="aca-it@uw.edu",
     include_package_data=True,
     install_requires=[
-        'Django>2.2,<5',
+        'Django>3.2,<5',
         'django-userservice',
         'django-user-agents',
         'mock',
     ],
     license='Apache License, Version 2.0',
     description=('A Django application used for theming and wrapping '
-                 'AXDD support tools.'),
+                 'T&LS support tools.'),
     long_description=README,
     url=url,
     classifiers=[
@@ -37,6 +37,5 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/supporttools/context_processors.py
+++ b/supporttools/context_processors.py
@@ -1,6 +1,5 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
-
 
 from django.conf import settings
 from userservice.user import UserService

--- a/supporttools/models.py
+++ b/supporttools/models.py
@@ -1,7 +1,0 @@
-# Copyright 2023 UW-IT, University of Washington
-# SPDX-License-Identifier: Apache-2.0
-
-
-from django.db import models
-
-# Create your models here.

--- a/supporttools/templatetags/sidebar_links.py
+++ b/supporttools/templatetags/sidebar_links.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/supporttools/tests/__init__.py
+++ b/supporttools/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/supporttools/tests/test_context_processors.py
+++ b/supporttools/tests/test_context_processors.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -45,7 +45,7 @@ class TestContextProcessors(TestCase):
         with self.settings(GOOGLE_ANALYTICS_KEY="ga_1234"):
             values = has_google_analytics(get_request())
             self.assertTrue(values["has_google_analytics"])
-            self.assertEquals(values["GOOGLE_ANALYTICS_KEY"], "ga_1234")
+            self.assertEqual(values["GOOGLE_ANALYTICS_KEY"], "ga_1234")
 
     def test_missing_google_analytics(self):
         with self.settings(GOOGLE_ANALYTICS_KEY=None):

--- a/supporttools/tests/test_sidebar_links.py
+++ b/supporttools/tests/test_sidebar_links.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/supporttools/urls.py
+++ b/supporttools/urls.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/supporttools/views.py
+++ b/supporttools/views.py
@@ -1,4 +1,4 @@
-# Copyright 2023 UW-IT, University of Washington
+# Copyright 2024 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
 


### PR DESCRIPTION
Enable deprecation warnings, update django test matrix, drop python-dev install